### PR TITLE
Terraform and AWS provider version upgrade (DO-754)

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,5 +1,7 @@
 # State
 terraform {
+  required_version="0.11.14"
+
   backend "s3" {
     region         = "us-east-1"
     bucket         = "centeredgeterraform"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,5 @@
+resource "aws_iam_user" "BackupUploader" {
+    name          = "BackupUploader"
+    path          = "/"
+    force_destroy = "false"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -5,7 +5,7 @@ provider "aws" {
     role_arn = "arn:aws:iam::833738481970:role/Deployer"
   }
 
-  version = "~> 2.0"
+  version = "~> 2.52"
 }
 
 provider "local" {


### PR DESCRIPTION
Motivation:
----------
Prior to making the jump to Terraform 12 all repos should be synced and using Terraform v0.11.14 to allow remote state cross version support.  In addition AWS provider should be brought up to latest as well

Modifications:
----------
All terraform workspaces in this repo:
* Upgraded to Terraform v0.11.14
* Upgraded AWS provider to 2.52
* Synced with AWS infrastructure, some terraform changes made to reflect what must have been manually changed within AWS at some point

Results:
----------
* Repos now using Terraform v0.11.14 and AWS provider 2.52

https://centeredge.atlassian.net/browse/DO-754