### PR TITLE
Terraform Cleanup/Standardization (DO-1176)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,12 @@
 root = true
 
-[*.tf]
+[terraform/**/*]
 indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
+
 
 [*.ps1]
 indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "terraform-ls.rootModules": [
+        "terraform"
+    ],
+    "[terraform]": {
+        "editor.formatOnSave": true
+    },
+    "terraform-ls.experimentalFeatures": {
+        "validateOnSave": true
+    }
+}

--- a/terraform/.gitattributes
+++ b/terraform/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,41 +2,42 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.70.0"
-  constraints = "~> 2.52"
+  version     = "3.4.0"
+  constraints = "~> 3.4.0"
   hashes = [
-    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
-    "zh:01a5f351146434b418f9ff8d8cc956ddc801110f1cc8b139e01be2ff8c544605",
-    "zh:1ec08abbaf09e3e0547511d48f77a1e2c89face2d55886b23f643011c76cb247",
-    "zh:606d134fef7c1357c9d155aadbee6826bc22bc0115b6291d483bc1444291c3e1",
-    "zh:67e31a71a5ecbbc96a1a6708c9cc300bbfe921c322320cdbb95b9002026387e1",
-    "zh:75aa59ae6f0834ed7142c81569182a658e4c22724a34db5d10f7545857d8db0c",
-    "zh:76880f29fca7a0a3ff1caef31d245af2fb12a40709d67262e099bc22d039a51d",
-    "zh:aaeaf97ffc1f76714e68bc0242c7407484c783d604584c04ad0b267b6812b6dc",
-    "zh:ae1f88d19cc85b2e9b6ef71994134d55ef7830fd02f1f3c58c0b3f2b90e8b337",
-    "zh:b155bdda487461e7b3d6e3a8d5ce5c887a047e4d983512e81e2c8266009f2a1f",
-    "zh:ba394a7c391a26c4a91da63ad680e83bde0bc1ecc0a0856e26e9d62a4e77c408",
-    "zh:e243c9d91feb0979638f28eb26f89ebadc179c57a2bd299b5729fb52bd1902f2",
-    "zh:f6c05e20d9a3fba76ca5f47206dde35e5b43b6821c6cbf57186164ce27ba9f15",
+    "h1:iecnARpPvfrGo8Ufjs84fxvGjNrIH1MI9BPbK/ZPXYI=",
+    "h1:jNLbGXTgtPjbsBRIpfqifA9QhHu6MsMltCjpAXUzZnE=",
+    "h1:t71AZiZ0m7BrRcv7rU0lCjHRx4lvfjIpC324Q7Z06Lk=",
+    "zh:055a6cad66556cf1bf596def42c4bf04a6ee064d2b7cb6f58be1054e3e1de7d0",
+    "zh:4a03919cfe929da2d1848ba867b6a4efd417a12a70b9fda2189eada6b64f033a",
+    "zh:50be044b929578433dd1b88a4470d19a36a577a07d7f7fccb234ac8ab846e02b",
+    "zh:50dae26140e57209134941424107c416b0401bfe126c54100d145d56450c2d04",
+    "zh:7ba069bbf4b420ce37d5b8116e08e7f6bf593e28e8f94b5a87636a5e33d13da8",
+    "zh:8354822b2ff090da83f6a19965e062985b9e1a90ad36fdd5a6959185c591e301",
+    "zh:85ddeb38ae83ddf50767a7ca057b732f046fb2e8e26f3e4b78b132a9012081e1",
+    "zh:94139f48a17173a7dc0503fbf6110b28b86b13dd29d2a87bc4938997f257a4bc",
+    "zh:b8efeae190cedc2acec95c215ce7a401f841d0f3adc4e5ce59847036a801dc95",
+    "zh:c1e555fd0dcd771cadc7aa511b65362002aa163c5f5d5e51b788f8736ca43188",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version     = "1.4.0"
-  constraints = "~> 1.3"
+  version     = "2.1.0"
+  constraints = "~> 2.1.0"
   hashes = [
-    "h1:zpODcKdAy9V1Jqfl+gfLvnL7UVwK52QlGJP7bqDtbT4=",
-    "zh:1b265fcfdce8cc3ccb51969c6d7a61531bf8a6e1218d95c1a74c40f25595c74b",
-    "zh:2ea6d8c503a1119b80a273eacd187516347c00a54990c47d130235e2ad53d163",
-    "zh:38bcc4a224d2c0745015564b0803a368b2bd08d1a3e349783bc4c09c68fde24b",
-    "zh:3fada9c646bf57bcdd6844d7c30153407a2a8100811daa69fc0d674fb39a9d18",
-    "zh:74ccb372e752188ba4ff1b1280222d6fd61bdf29dcf474edb8ea63178897912c",
-    "zh:7a323f05ccd7caa1450301af1bb7cac25e2d6ac799eb581219c2c663e5d9ae3f",
-    "zh:7ef13da7e8ae7129fae8a9c72845d52d4586db496359228ed435aeab2f44aea8",
-    "zh:9df7edb284f5548918b839b18204c6a78ac33b4df070d4e4a5c264bb11152e9c",
-    "zh:b062919beaca2e06fd3b333b700dae664828fe734479e51c2c28b8219286e0fc",
-    "zh:ca9fe963f261236b3f3308f8b4979cdd95dd68281b00c1c18a6d17db07519ac8",
-    "zh:e125e4a7d838e231a88e0efc1e727f5a1807db5c0cad5e1cbaf1b52c560b47c7",
-    "zh:f3c3bbab3785f00433135538bdb697d516bc43f102c1b128a0c1419b172e88f6",
+    "h1:/OpJKWupvFd8WJX1mTt8vi01pP7dkA6e//4l4C3TExE=",
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
   ]
 }

--- a/terraform/setup.tf
+++ b/terraform/setup.tf
@@ -5,11 +5,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.52"
+      version = "~> 3.4.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.3"
+      version = "~> 2.1.0"
     }
   }
 


### PR DESCRIPTION
Motivation:
----------
Terraform workspaces should be standardized on provider versions
Running `terraform init` ( without `--upgrade` ) will install same provider version for all platforms
Run cleanly cross OS when no source changes have been made

Modifications:
----------
* Changed `.editorconfig` to use `LF` for terraform files
* Add/modified `.gitattributes` to force `LF` endings for terraform files

_NOTE: Developers will have to run `git rm --cached -r .` and then `git reset --hard` to reset the line endings after pulling latest.  Verify line endings with `git ls-files --eol` everything under `**/terraform/*` should be `LF`_

* Required provider versions upgraded as needed
* Breaking changes due to provider upgrade addressed

Results:
----------
* Runs cleanly on both linux and windows

https://centeredge.atlassian.net/browse/DO-1176
