### PR TITLE
Fix devcontainer cross OS mounts (DO-1847)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,9 @@
     }
   },
   "mounts": [
-    "source=${env:HOME}/.aws,target=/home/vscode/.aws,type=bind",
-    "source=${env:HOME}/.gitignore,target=/home/vscode/.gitignore,type=bind",
-    "source=${env:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind"
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/home/vscode/.aws,type=bind",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitignore,target=/home/vscode/.gitignore,type=bind",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig,target=/home/vscode/.gitconfig,type=bind"
   ],
   "remoteUser": "vscode",
   // Add the IDs of extensions you want installed when the container is created.


### PR DESCRIPTION
Motivation
---
Fix devcontainer so mounts work for both windows and *nix

Modification
---
* Now looks for both `HOME` and `USERPROFILE` environment variables in host system
* Cleaned up deprecated devcontainer issues

Result
---
Devcontainer builds and works, terraform runs cleanly.

https://centeredge.atlassian.net/browse/DO-1847