### PR TITLE
Import CenterEdgeOps legacy assets (DATA-626)

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 4.57.1"
   hashes = [
     "h1:buAar4hEPW5TtnnPtKib6JFV8uHuMk5FJF2Bo73PuO4=",
+    "h1:qIwRZ8raS3uMsGpmFKHJzTvCJ3kAOB02tyP4tHQJ328=",
     "zh:44200c213ddb138df80d2a5ad86c2ebadbb5fd1d08cd7e4fc56ec6dca927659b",
     "zh:469e6fe6a9e99e60cb168d32f05e2e9a83cf161f39160d075ff96f7674c510e1",
     "zh:6110ba2c15a2268652ec9ea3797dd0216de84ece428055c49eaf9caa2be1ed62",

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,3 @@
+resource "aws_acm_certificate" "ops-dashboards-lb" {
+  domain_name = "dashboard.ops.centeredgesoftware.com"
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,10 +1,3 @@
-locals {
-  SupportOps = {
-    subnet_id        = "subnet-912380ba"
-    instance_profile = "SupportBot"
-  }
-}
-
 resource "aws_instance" "SupportOps" {
   ami                         = "ami-0204606704df03e7e"
   availability_zone           = "us-east-1b"
@@ -12,12 +5,12 @@ resource "aws_instance" "SupportOps" {
   instance_type               = "t3a.large"
   monitoring                  = false
   key_name                    = "CenterEdgeOps"
-  subnet_id                   = local.SupportOps["subnet_id"]
-  vpc_security_group_ids      = ["sg-09f54559649a9d490"]
+  subnet_id                   = aws_subnet.supportops-server-1.id
+  vpc_security_group_ids      = [aws_security_group.supportops.id]
   associate_public_ip_address = true
   private_ip                  = "172.16.0.248"
   source_dest_check           = true
-  iam_instance_profile        = local.SupportOps["instance_profile"]
+  iam_instance_profile        = aws_iam_instance_profile.supportops-server.name
   disable_api_termination     = "true"
 
   root_block_device {
@@ -35,3 +28,84 @@ resource "aws_instance" "SupportOps" {
   )
 }
 
+resource "aws_eip" "supportops-server" {
+  instance = aws_instance.SupportOps.id
+}
+
+# Training Virtuals
+resource "aws_launch_template" "training-virtuals" {
+  name            = "Training_Virtual_Server"
+  instance_type   = "t3a.medium"
+  key_name        = "CenterEdgeOps"
+  tags            = {}
+  default_version = 39
+
+  disable_api_termination = true
+  ebs_optimized           = false
+
+  image_id  = aws_ami.training-virtuals-2023.id
+  user_data = base64encode(file("./resources/training-virtual-user-data.txt"))
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.training-virtuals.arn
+  }
+
+  network_interfaces {
+    device_index       = 0
+    ipv4_address_count = 0
+    ipv4_addresses     = []
+    ipv4_prefix_count  = 0
+    ipv4_prefixes      = []
+    ipv6_address_count = 0
+    ipv6_addresses     = []
+    ipv6_prefix_count  = 0
+    ipv6_prefixes      = []
+    security_groups = [
+      aws_security_group.training-virtuals.id
+    ]
+    subnet_id = aws_subnet.training-virtuals-1.id
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "BillingEnvironment"      = "Ops"
+      "DevOpsAutomatorTaskList" = "SnapshotDailyMin"
+      "Name"                    = ""
+    }
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = {
+      "BillingEnvironment" = "Ops"
+      "Name"               = ""
+    }
+  }
+}
+
+resource "aws_ami" "training-virtuals-2023" {
+  name                = "Training Virtual Template - v23.1.0"
+  virtualization_type = "hvm"
+  tags                = {}
+
+  ena_support      = true
+  root_device_name = "/dev/sda1"
+
+  ebs_block_device {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    encrypted             = false
+    iops                  = 0
+    snapshot_id           = aws_ebs_snapshot.training-virtuals-2023.id
+    throughput            = 0
+    volume_size           = 50
+    volume_type           = "gp2"
+  }
+}
+
+resource "aws_ebs_snapshot" "training-virtuals-2023" {
+  description = "Created by CreateImage(i-0850362de4528c2a5) for ami-042c90987367ddb79"
+  volume_id   = "vol-04134b8375577b07f"
+  tags        = {}
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -5,9 +5,9 @@ resource "aws_iam_user" "BackupUploader" {
 }
 
 resource "aws_iam_role" "backupadmin" {
-    name               = "BackupAdmin"
-    path               = "/"
-    assume_role_policy = data.aws_iam_policy_document.backupadmin-assumepolicy.json
+  name               = "BackupAdmin"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.backupadmin-assumepolicy.json
 }
 
 data "aws_iam_policy_document" "backupadmin" {
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "backupadmin" {
   }
 
   statement {
-    sid     = "BucketObjAllActions"
+    sid = "BucketObjAllActions"
     actions = [
       "s3:PutObject",
       "s3:PutObjectAcl",
@@ -37,10 +37,10 @@ data "aws_iam_policy_document" "backupadmin" {
 }
 
 resource "aws_iam_policy" "backupadmin" {
-    name        = "BackupAdmin"
-    path        = "/"
-    description = "Allows readwrite to everything in centeredge-db-backup bucket"
-    policy      = data.aws_iam_policy_document.backupadmin.json
+  name        = "BackupAdmin"
+  path        = "/"
+  description = "Allows readwrite to everything in centeredge-db-backup bucket"
+  policy      = data.aws_iam_policy_document.backupadmin.json
 }
 
 data "aws_iam_policy_document" "backupadmin-assumepolicy" {
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "backupadmin-assumepolicy" {
       type        = "AWS"
       identifiers = ["arn:aws:iam::472171537141:root"]
     }
-    condition  {
+    condition {
       test     = "Bool"
       variable = "aws:MultiFactorAuthPresent"
       values   = ["true"]
@@ -69,4 +69,141 @@ data "aws_iam_policy_document" "backupadmin-assumepolicy" {
 resource "aws_iam_role_policy_attachment" "backupadmin" {
   role       = aws_iam_role.backupadmin.name
   policy_arn = aws_iam_policy.backupadmin.arn
+}
+
+# SupportOps
+
+resource "aws_iam_instance_profile" "supportops-server" {
+  name = "SupportBot"
+  role = aws_iam_role.supportops-server.name
+}
+
+resource "aws_iam_role" "supportops-server" {
+  name               = "SupportBot"
+  description        = "Allows EC2 instances to call AWS services on your behalf."
+  assume_role_policy = data.aws_iam_policy_document.ec2-assumepolicy.json
+}
+
+resource "aws_iam_role_policy_attachment" "supportops-pass-to-virtuals" {
+  role       = aws_iam_role.supportops-server.name
+  policy_arn = aws_iam_policy.pass-role-to-training-virtuals.arn
+}
+
+resource "aws_iam_role_policy_attachment" "supportops-assume-support-bot" {
+  role       = aws_iam_role.supportops-server.name
+  policy_arn = aws_iam_policy.assume-support-bot.arn
+}
+
+resource "aws_iam_role_policy_attachment" "supportops-ssm-full-access" {
+  role       = aws_iam_role.supportops-server.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "supportops-ec2-full-access" {
+  role       = aws_iam_role.supportops-server.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "supportops-cloudwatch-read-only" {
+  role       = aws_iam_role.supportops-server.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "supportops-resource-groups-read-only" {
+  role       = aws_iam_role.supportops-server.name
+  policy_arn = "arn:aws:iam::aws:policy/ResourceGroupsandTagEditorReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "pass-role-to-training-virtuals" {
+  name   = "AllowPassRoleToVirtuals"
+  policy = data.aws_iam_policy_document.pass-role-to-training-virtuals.json
+}
+
+data "aws_iam_policy_document" "pass-role-to-training-virtuals" {
+  statement {
+    sid       = "AllowPassRoleToEc2Instances"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::833738481970:role/CustomerServer"]
+  }
+}
+
+resource "aws_iam_policy" "assume-support-bot" {
+  name   = "AssumeSupportBot"
+  policy = data.aws_iam_policy_document.assume-support-bot.json
+}
+
+data "aws_iam_policy_document" "assume-support-bot" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    resources = [
+      "arn:aws:iam::356285239608:role/SupportBot",
+      "arn:aws:iam::243399810067:role/SupportBot",
+      "arn:aws:iam::833738481970:role/SupportOps"
+    ]
+  }
+}
+
+# Training Virtuals
+
+resource "aws_iam_instance_profile" "training-virtuals" {
+  name = "CustomerServer"
+  role = aws_iam_role.training-virtuals.name
+}
+
+resource "aws_iam_role" "training-virtuals" {
+  name               = "CustomerServer"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ec2-assumepolicy.json
+}
+
+resource "aws_iam_role_policy_attachment" "training-virtuals-self-tagging" {
+  role       = aws_iam_role.training-virtuals.name
+  policy_arn = aws_iam_policy.training-virtuals-self-tagging.arn
+}
+
+resource "aws_iam_role_policy_attachment" "training-virtuals-upload-backups" {
+  role       = aws_iam_role.training-virtuals.name
+  policy_arn = aws_iam_policy.upload-backups.arn
+}
+
+resource "aws_iam_policy" "training-virtuals-self-tagging" {
+  policy = data.aws_iam_policy_document.allow-self-tagging.json
+}
+
+data "aws_iam_policy_document" "allow-self-tagging" {
+  statement {
+    sid = "SelfTaggingOnly"
+    actions = [
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+      "ec2:DescribeTags"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "upload-backups" {
+  policy = data.aws_iam_policy_document.upload-backups.json
+}
+
+data "aws_iam_policy_document" "upload-backups" {
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::centeredge-db-backup/*"]
+  }
+
+  statement {
+    actions   = ["ec2:DescribeTags"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "ec2-assumepolicy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
 }

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,0 +1,156 @@
+
+resource "aws_lb" "ops-dashboards" {
+  name            = "grafana"
+  security_groups = ["sg-09f54559649a9d490"]
+
+  subnet_mapping {
+    subnet_id = "subnet-777cc62e"
+  }
+  subnet_mapping {
+    subnet_id = "subnet-912380ba"
+  }
+}
+
+resource "aws_lb_listener" "grafana" {
+  load_balancer_arn = aws_lb.ops-dashboards.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.ops-dashboards-lb.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.grafana.arn
+  }
+}
+
+resource "aws_lb_listener" "http-redirect" {
+  load_balancer_arn = aws_lb.ops-dashboards.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "slack-bot" {
+  load_balancer_arn = aws_lb.ops-dashboards.arn
+  port              = 7117
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.ops-dashboards-lb.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.slack-bot.arn
+  }
+}
+
+resource "aws_lb_listener" "api" {
+  load_balancer_arn = aws_lb.ops-dashboards.arn
+  port              = 5050
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.ops-dashboards-lb.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+resource "aws_lb_target_group" "grafana" {
+  name                          = "grafana-server"
+  port                          = 80
+  protocol                      = "HTTP"
+  protocol_version              = "HTTP1"
+  connection_termination        = false
+  ip_address_type               = "ipv4"
+  load_balancing_algorithm_type = "round_robin"
+  proxy_protocol_v2             = false
+  tags_all                      = {}
+  vpc_id                        = "vpc-67692002"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 5
+    interval            = 30
+    matcher             = "200"
+    path                = "/login"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 2
+  }
+
+  stickiness {
+    cookie_duration = 86400
+    enabled         = false
+    type            = "lb_cookie"
+  }
+}
+
+resource "aws_lb_target_group" "slack-bot" {
+  name                          = "slack-bot"
+  port                          = 7117
+  protocol                      = "HTTP"
+  protocol_version              = "HTTP1"
+  connection_termination        = false
+  ip_address_type               = "ipv4"
+  load_balancing_algorithm_type = "round_robin"
+  proxy_protocol_v2             = false
+  tags_all                      = {}
+  vpc_id                        = "vpc-67692002"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 5
+    interval            = 300
+    matcher             = "200"
+    path                = "/healthcheck"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 2
+  }
+
+  stickiness {
+    cookie_duration = 86400
+    enabled         = false
+    type            = "lb_cookie"
+  }
+}
+
+resource "aws_lb_target_group" "api" {
+  name                          = "api"
+  port                          = 5050
+  protocol                      = "HTTP"
+  protocol_version              = "HTTP1"
+  connection_termination        = false
+  ip_address_type               = "ipv4"
+  load_balancing_algorithm_type = "round_robin"
+  proxy_protocol_v2             = false
+  tags_all                      = {}
+  vpc_id                        = "vpc-67692002"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 5
+    interval            = 30
+    matcher             = "200"
+    path                = "/live"
+    port                = 5051
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 2
+  }
+
+  stickiness {
+    cookie_duration = 86400
+    enabled         = false
+    type            = "lb_cookie"
+  }
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,135 @@
+# SupportOps
+
+resource "aws_vpc" "supportops" {
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    AWSServiceAccount = "697148468905"
+  }
+}
+
+resource "aws_internet_gateway" "supportops" {
+  vpc_id = aws_vpc.supportops.id
+  tags = {
+    AWSServiceAccount = "697148468905"
+  }
+}
+
+resource "aws_route_table" "supportops" {
+  vpc_id = aws_vpc.supportops.id
+  tags = {
+    AWSServiceAccount = "697148468905"
+  }
+}
+
+resource "aws_route" "supportops-internet-access" {
+  route_table_id         = aws_route_table.supportops.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.supportops.id
+}
+
+resource "aws_subnet" "supportops-server-1" {
+  vpc_id            = aws_vpc.supportops.id
+  cidr_block        = "172.16.0.0/24"
+  availability_zone = "us-east-1b"
+  tags = {
+    AWSServiceAccount = "697148468905"
+  }
+
+  private_dns_hostname_type_on_launch = "ip-name"
+}
+
+resource "aws_subnet" "supportops-server-2" {
+  vpc_id            = aws_vpc.supportops.id
+  cidr_block        = "172.16.1.0/24"
+  availability_zone = "us-east-1d"
+  tags = {
+    AWSServiceAccount = "697148468905"
+  }
+
+  private_dns_hostname_type_on_launch = "ip-name"
+}
+
+resource "aws_route_table_association" "supportops-server-1" {
+  subnet_id      = aws_subnet.supportops-server-1.id
+  route_table_id = aws_route_table.supportops.id
+}
+
+resource "aws_route_table_association" "supportops-server-2" {
+  subnet_id      = aws_subnet.supportops-server-2.id
+  route_table_id = aws_route_table.supportops.id
+}
+
+resource "aws_security_group" "supportops-db" {
+  name        = "SupportOps-DB"
+  description = "Created by RDS management console"
+  vpc_id      = aws_vpc.supportops.id
+  tags        = {}
+}
+
+resource "aws_vpc_security_group_egress_rule" "supportops-db-default" {
+  security_group_id = aws_security_group.supportops-db.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-db-supportops-server" {
+  description       = "DataServer"
+  security_group_id = aws_security_group.supportops-db.id
+
+  referenced_security_group_id = "sg-09f54559649a9d490"
+  ip_protocol                  = "tcp"
+  from_port                    = 5432
+  to_port                      = 5432
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-db-centeredge" {
+  description       = "CE"
+  security_group_id = aws_security_group.supportops-db.id
+
+  cidr_ipv4   = "63.234.202.58/32"
+  ip_protocol = "tcp"
+  from_port   = 5432
+  to_port     = 5432
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-db-quicksight" {
+  description       = "QuickSight us-east-1"
+  security_group_id = aws_security_group.supportops-db.id
+
+  cidr_ipv4   = "52.23.63.224/27"
+  ip_protocol = "tcp"
+  from_port   = 5432
+  to_port     = 5432
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-db-google-servers-1" {
+  description       = "Google"
+  security_group_id = aws_security_group.supportops-db.id
+
+  cidr_ipv6   = "2001:4860:4807::/48"
+  ip_protocol = "tcp"
+  from_port   = 5432
+  to_port     = 5432
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-db-google-servers-2" {
+  description       = "Google"
+  security_group_id = aws_security_group.supportops-db.id
+
+  cidr_ipv4   = "74.125.0.0/16"
+  ip_protocol = "tcp"
+  from_port   = 5432
+  to_port     = 5432
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-db-google-servers-3" {
+  description       = "Google"
+  security_group_id = aws_security_group.supportops-db.id
+
+  cidr_ipv4   = "142.251.74.0/23"
+  ip_protocol = "tcp"
+  from_port   = 5432
+  to_port     = 5432
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,3 +1,36 @@
+# Training Virtuals
+
+resource "aws_vpc" "training-virtuals" {
+  cidr_block           = "172.31.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_internet_gateway" "training-virtuals" {
+  vpc_id = aws_vpc.training-virtuals.id
+}
+
+resource "aws_route_table" "training-virtuals" {
+  vpc_id = aws_vpc.training-virtuals.id
+}
+
+resource "aws_route" "training-virtuals-internet-access" {
+  route_table_id         = aws_route_table.training-virtuals.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.training-virtuals.id
+}
+
+resource "aws_subnet" "training-virtuals-1" {
+  vpc_id                  = aws_vpc.training-virtuals.id
+  cidr_block              = "172.31.80.0/20"
+  availability_zone       = "us-east-1f"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_route_table_association" "training-virtuals" {
+  subnet_id      = aws_subnet.training-virtuals-1.id
+  route_table_id = aws_route_table.training-virtuals.id
+}
+
 # SupportOps
 
 resource "aws_vpc" "supportops" {
@@ -132,4 +165,163 @@ resource "aws_vpc_security_group_ingress_rule" "supportops-db-google-servers-3" 
   ip_protocol = "tcp"
   from_port   = 5432
   to_port     = 5432
+}
+
+resource "aws_security_group" "supportops" {
+  name        = "SupportOps"
+  description = "launch-wizard-6 created 2019-05-20T14:00:13.438-04:00"
+  vpc_id      = aws_vpc.supportops.id
+  tags        = {}
+}
+
+resource "aws_vpc_security_group_egress_rule" "supportops-default" {
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-centeredge-access" {
+  description       = "CEAlternate"
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv4   = "63.234.202.58/32"
+  ip_protocol = "tcp"
+  from_port   = 3389
+  to_port     = 3389
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-public-http-ipv4" {
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 80
+  to_port     = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-public-https-ipv4" {
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-public-http-ipv6" {
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv6   = "::/0"
+  ip_protocol = "tcp"
+  from_port   = 80
+  to_port     = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-public-slack-ipv4" {
+  description       = "Slack"
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 7117
+  to_port     = 7117
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-public-slack-ipv6" {
+  description       = "Slack"
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv6   = "::/0"
+  ip_protocol = "tcp"
+  from_port   = 7117
+  to_port     = 7117
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-public-api-ipv4" {
+  description       = "Api"
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 5050
+  to_port     = 5050
+}
+
+resource "aws_vpc_security_group_ingress_rule" "supportops-public-api-ipv4-health-check" {
+  description       = "Api Health"
+  security_group_id = aws_security_group.supportops.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 5051
+  to_port     = 5051
+}
+
+# Training Virtuals
+
+resource "aws_security_group" "training-virtuals" {
+  name        = "CustomerServer"
+  description = "All access necessary for a customer server"
+  vpc_id      = aws_vpc.training-virtuals.id
+  tags        = {}
+}
+
+resource "aws_vpc_security_group_egress_rule" "training-virtuals-default" {
+  security_group_id = aws_security_group.training-virtuals.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "training-virtuals-http" {
+  security_group_id = aws_security_group.training-virtuals.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 80
+  to_port     = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "training-virtuals-https" {
+  security_group_id = aws_security_group.training-virtuals.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+}
+
+resource "aws_vpc_security_group_ingress_rule" "training-virtuals-smtp" {
+  security_group_id = aws_security_group.training-virtuals.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 587
+  to_port     = 587
+}
+
+resource "aws_vpc_security_group_ingress_rule" "training-virtuals-rdp" {
+  security_group_id = aws_security_group.training-virtuals.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 3389
+  to_port     = 3389
+}
+
+resource "aws_vpc_security_group_ingress_rule" "training-virtuals-vnc" {
+  security_group_id = aws_security_group.training-virtuals.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 5900
+  to_port     = 5900
+}
+
+resource "aws_vpc_security_group_ingress_rule" "training-virtuals-all-icmp" {
+  security_group_id = aws_security_group.training-virtuals.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "icmp"
 }

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,63 @@
+resource "aws_db_instance" "supportops-database" {
+  instance_class = "db.t3.medium"
+  db_name        = "grafana"
+  identifier     = "supportops"
+  engine         = "postgres"
+  tags           = {}
+
+  storage_type                    = "gp2"
+  allocated_storage               = 20
+  max_allocated_storage           = 40
+  monitoring_interval             = 60
+  backup_retention_period         = 3
+  backup_window                   = "06:00-08:00"
+  maintenance_window              = "Sun:00:00-Sun:04:00"
+  parameter_group_name            = aws_db_parameter_group.supportops-db.name
+  kms_key_id                      = data.aws_kms_key.rds-default.arn
+  performance_insights_kms_key_id = data.aws_kms_key.rds-default.arn
+
+  port                   = 5432
+  network_type           = "IPV4"
+  vpc_security_group_ids = [aws_security_group.supportops-db.id]
+  db_subnet_group_name   = aws_db_subnet_group.supportops-db.name
+
+  auto_minor_version_upgrade   = true
+  storage_encrypted            = true
+  copy_tags_to_snapshot        = true
+  deletion_protection          = true
+  performance_insights_enabled = true
+  publicly_accessible          = true
+  skip_final_snapshot          = true
+}
+
+data "aws_kms_key" "rds-default" {
+  key_id = "arn:aws:kms:us-east-1:833738481970:key/a7e2e160-d781-4734-833b-2827180c850c"
+}
+
+resource "aws_db_subnet_group" "supportops-db" {
+  name = "default-vpc-67692002"
+  subnet_ids = [
+    aws_subnet.supportops-server-1.id,
+    aws_subnet.supportops-server-2.id
+  ]
+}
+
+resource "aws_db_option_group" "supportops-db" {
+  option_group_description = "Default option group for postgres 11"
+  engine_name              = "postgres"
+  major_engine_version     = "11"
+  tags                     = {}
+}
+
+resource "aws_db_parameter_group" "supportops-db" {
+  name        = "default-with-mod-logging"
+  description = "Adds logging for mod statements (INSERT, UPDATE, DELETE, etc)."
+  family      = "postgres11"
+  tags        = {}
+
+  parameter {
+    apply_method = "immediate"
+    name         = "log_statement"
+    value        = "none"
+  }
+}

--- a/terraform/resources/training-virtual-user-data.txt
+++ b/terraform/resources/training-virtual-user-data.txt
@@ -1,0 +1,11 @@
+<powershell>
+$saPass = '';
+$posPass = '';
+$winPass = '';
+$tvPass = '';
+
+if ($saPass -ne ([String]::Empty) -and $posPass -ne ([String]::Empty) -and $winPass -ne ([String]::Empty)) {
+$SiteName = 'CenterEdge Software';
+C:\Users\Administrator\Documents\WindowsPowerShell\Install-VirtualServer.ps1 -saPass $saPass -posPass $posPass -winPass $winPass -tvPass $tvPass -SiteName $SiteName
+}
+</powershell>

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,101 @@
+resource "aws_s3_bucket" "centeredge-ops-emails" {
+  bucket = "centeredge-ops-emails"
+  tags   = {}
+}
+
+resource "aws_s3_bucket_policy" "centeredge-ops-emails" {
+  bucket = aws_s3_bucket.centeredge-ops-emails.id
+  policy = data.aws_iam_policy_document.allow-ses-put.json
+}
+
+data "aws_iam_policy_document" "allow-ses-put" {
+  statement {
+    sid       = "AllowSESPuts"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::centeredge-ops-emails/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["ses.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:Referer"
+      values   = ["833738481970"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "centeredge-ops-emails" {
+  bucket = aws_s3_bucket.centeredge-ops-emails.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "centeredge-ops-emails" {
+  bucket = aws_s3_bucket.centeredge-ops-emails.id
+  rule {
+    id = "ExpireObjects"
+    filter {}
+    status = "Enabled"
+    expiration {
+      days = 365
+    }
+  }
+}
+
+resource "aws_s3_bucket" "centeredge-install" {
+  bucket = "centeredge-install"
+  tags   = {}
+}
+
+resource "aws_s3_bucket_policy" "centeredge-install" {
+  bucket = aws_s3_bucket.centeredge-install.id
+  policy = data.aws_iam_policy_document.allow-public-read.json
+}
+
+data "aws_iam_policy_document" "allow-public-read" {
+  statement {
+    sid       = "PublicReadGetObject"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::centeredge-install/*"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "centeredge-install" {
+  bucket = aws_s3_bucket.centeredge-install.id
+
+  block_public_acls       = true
+  block_public_policy     = false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_acl" "centeredge-install" {
+  bucket = aws_s3_bucket.centeredge-install.id
+
+  access_control_policy {
+    grant {
+      grantee {
+        id   = "82f47eee41dcd98b5e5b48dab0ecbb5353004ac653094d9387867354c76dd925"
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+    owner {
+      display_name = "sreilly"
+      id           = "82f47eee41dcd98b5e5b48dab0ecbb5353004ac653094d9387867354c76dd925"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "centeredgeops" {
+  bucket = "centeredgeops"
+  tags   = {}
+}

--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -1,0 +1,18 @@
+resource "aws_ses_receipt_rule_set" "adv-emails" {
+  rule_set_name = "default-rule-set"
+}
+
+resource "aws_ses_receipt_rule" "adv-emails-parse" {
+  name          = "ParseEmail"
+  rule_set_name = "default-rule-set"
+
+  enabled      = true
+  scan_enabled = true
+  recipients   = ["ops.centeredge.io"]
+
+  s3_action {
+    bucket_name = "centeredge-ops-emails"
+    position    = 1
+    topic_arn   = aws_sns_topic.adv-email-received.arn
+  }
+}

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -1,0 +1,34 @@
+resource "aws_sns_topic" "adv-email-received" {
+  name   = "support_email_saved_to_s3"
+  policy = data.aws_iam_policy_document.adv-emails-access-policy.json
+  tags   = {}
+
+  content_based_deduplication = false
+  fifo_topic                  = false
+}
+
+data "aws_iam_policy_document" "adv-emails-access-policy" {
+  statement {
+    actions = [
+      "SNS:GetTopicAttributes",
+      "SNS:SetTopicAttributes",
+      "SNS:AddPermission",
+      "SNS:RemovePermission",
+      "SNS:DeleteTopic",
+      "SNS:Subscribe",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:Publish",
+      "SNS:Receive"
+    ]
+    resources = ["arn:aws:sns:us-east-1:833738481970:support_email_saved_to_s3"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+      values   = ["833738481970"]
+    }
+  }
+}


### PR DESCRIPTION
Motivation
---
It has been a longstanding issue that legacy Operations resources in AWS were not imported into this terraform repo. This is the beginning of efforts to import those resources and manage them in terraform going forward.

Modifications
---
Added to terraform:

- The load balancer and related items that serve traffic for Grafana and Jarvis.
- The Postgres RDS instance that hosts Ops/Data information that is served in QuickSight, Grafana, and Jarvis.
- The permissions, launch templates, VPC, and related items that support Training Virtuals for Ops (the instances themselves are never expected to be included in Terraform)
- Added S3 buckets that are used to store Ops emails and the setup files for the Install team
- The SES and SNS resources that manage incoming Ops emails

NOTE 1: All of the resources added to terraform were imported. No new infrastructure was created as a part of this effort.

NOTE 2: Remaining resources to import include:

- A lambda function that processes incoming Ops emails.
- A dynamo DB database that hosts metadata about the processes Ops emails.

It appears as though these resources stopped working in 2021, so some effort will need to go in to updating them to a functioning state.

https://centeredge.atlassian.net/browse/DATA-626