### PR TITLE
Terraform v1.6 Upgrade (DO-2706)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
         "version": "latest"
     },
     "ghcr.io/devcontainers/features/terraform:1":  {
-        "version"     : "1.3.6",
+        "version"     : "1.6.1",
         "tflint"      : "latest",
         "installTFsec": true,
         "terragrunt"  : "none"

--- a/terraform/setup.tf
+++ b/terraform/setup.tf
@@ -1,6 +1,6 @@
 # State
 terraform {
-  required_version = "~> 1.3.6"
+  required_version = "~> 1.6.1"
 
   required_providers {
     aws = {
@@ -30,9 +30,11 @@ data "terraform_remote_state" "opsroot" {
     region         = "us-east-1"
     bucket         = "centeredgeterraform"
     key            = "OpsRoot/terraform.tfstate"
-    role_arn       = "arn:aws:iam::243399810067:role/TerraformDeployment"
     encrypt        = true
     dynamodb_table = "TerraformDeployment"
+    assume_role = {
+      role_arn = "arn:aws:iam::243399810067:role/TerraformDeployment"
+    }
   }
 }
 


### PR DESCRIPTION
Motivation
---
Upgrade from terraform `1.3` -> `1.6`

Modification
---
Updates to version and any deprecations

Result
---
Terraform runs cleanly in all workspaces

https://centeredge.atlassian.net/browse/DO-2706