### PR TITLE
CI for Jarvis in ECS with CodeDeploy (DATA-622)

### DIFF
--- a/terraform/codedeploy.tf
+++ b/terraform/codedeploy.tf
@@ -1,0 +1,55 @@
+resource "aws_codedeploy_app" "jarvis" {
+  compute_platform = "ECS"
+  name             = "AppECS-ops-jarvis"
+  tags             = local.default_tags
+}
+
+resource "aws_codedeploy_deployment_group" "jarvis" {
+  app_name               = aws_codedeploy_app.jarvis.name
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  deployment_group_name  = "DgpECS-ops-jarvis"
+  service_role_arn       = aws_iam_role.code-deploy-service-role.arn
+  tags                   = local.default_tags
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_REQUEST"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 10
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = aws_ecs_cluster.ops.name
+    service_name = aws_ecs_service.jarvis.name
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = [aws_lb_listener.jarvis.arn]
+      }
+
+      target_group {
+        name = aws_lb_target_group.jarvis-1.name
+      }
+
+      target_group {
+        name = aws_lb_target_group.jarvis-2.name
+      }
+    }
+  }
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,84 @@
+resource "aws_ecr_repository" "jarvis" {
+  name = "jarvis"
+  tags = local.default_tags
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = "arn:aws:kms:us-east-1:833738481970:key/9b73ca2b-d09a-4409-9120-6b9d5866c072"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecs_cluster" "ops" {
+  name = "ops"
+  tags = local.default_tags
+
+  configuration {
+    execute_command_configuration {
+      logging = "DEFAULT"
+    }
+  }
+
+  service_connect_defaults {
+    namespace = "arn:aws:servicediscovery:us-east-1:833738481970:namespace/ns-ww7pqjoncwsknlqc"
+  }
+}
+
+resource "aws_ecs_task_definition" "jarvis" {
+  family       = "jarvis"
+  cpu          = 512
+  memory       = 1024
+  network_mode = "awsvpc"
+  tags         = local.default_tags
+
+  container_definitions    = file("resources/jarvis-container-definitions.json")
+  task_role_arn            = aws_iam_role.jarvis.arn
+  execution_role_arn       = aws_iam_role.ecs-execution-role.arn
+  requires_compatibilities = ["FARGATE"]
+
+  runtime_platform {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "LINUX"
+  }
+}
+
+resource "aws_ecs_service" "jarvis" {
+  name             = "jarvis"
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
+  cluster          = aws_ecs_cluster.ops.id
+  task_definition  = format("%s:%s", "jarvis", aws_ecs_task_definition.jarvis.revision)
+  triggers         = {}
+  desired_count    = 1
+  iam_role         = "aws-service-role"
+  propagate_tags   = "NONE"
+  tags             = local.default_tags
+
+  enable_ecs_managed_tags           = true
+  health_check_grace_period_seconds = 0
+
+  deployment_controller {
+    type = "CODE_DEPLOY"
+  }
+
+  load_balancer {
+    // This can refer to jarvis-1 or jarvis-2, depending on the deployment status.
+    // If it conflicts with the current state, please update to match AWS rather
+    // than pushing this value.
+    target_group_arn = aws_lb_target_group.jarvis-2.arn
+    container_name   = "jarvis"
+    container_port   = 8080
+  }
+
+  network_configuration {
+    assign_public_ip = true
+    security_groups  = [aws_security_group.jarvis.id]
+    subnets = [
+      aws_subnet.supportops-server-1.id,
+      aws_subnet.supportops-server-2.id
+    ]
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -234,3 +234,244 @@ data "aws_iam_policy_document" "email-handler-assumepolicy" {
     }
   }
 }
+
+# jarvis ECS & CodeDeploy
+
+resource "aws_iam_role" "code-deploy-service-role" {
+  name               = "CodeDeployServiceRole"
+  assume_role_policy = data.aws_iam_policy_document.code-deploy-service-role-assume-policy.json
+  tags               = local.default_tags
+}
+
+data "aws_iam_policy_document" "code-deploy-service-role-assume-policy" {
+  statement {
+    sid     = ""
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+  statement {
+    sid     = ""
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["codedeploy.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "code-deploy-service-role" {
+  role       = aws_iam_role.code-deploy-service-role.name
+  policy_arn = aws_iam_policy.code-deploy-service-role.arn
+}
+
+resource "aws_iam_policy" "code-deploy-service-role" {
+  name        = "CodeDeployService"
+  description = "Allows access to ECS to perform deployments."
+  policy      = data.aws_iam_policy_document.code-deploy-service-role.json
+  tags        = local.default_tags
+}
+
+data "aws_iam_policy_document" "code-deploy-service-role" {
+  statement {
+    sid = "CodeDeployAllow"
+    actions = [
+      "sns:Publish",
+      "s3:GetObjectVersion",
+      "s3:GetObject",
+      "lambda:InvokeFunction",
+      "elasticloadbalancing:ModifyRule",
+      "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:DescribeListeners",
+      "ecs:UpdateServicePrimaryTaskSet",
+      "ecs:DescribeServices",
+      "ecs:DeleteTaskSet",
+      "ecs:CreateTaskSet",
+      "cloudwatch:DescribeAlarms"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "PassRolesInTaskDefinition"
+    actions = ["iam:PassRole"]
+    resources = [
+      "arn:aws:iam::833738481970:role/Jarvis",
+      "arn:aws:iam::833738481970:role/ecsTaskExecutionRole"
+    ]
+  }
+}
+
+resource "aws_iam_user" "jarvis-deployer" {
+  name = "jarvis-deployer"
+  path = "/"
+  tags = local.default_tags
+}
+
+resource "aws_iam_user_policy_attachment" "jarvis-deployer" {
+  user       = aws_iam_user.jarvis-deployer.name
+  policy_arn = aws_iam_policy.code-deploy-allow-ecs.arn
+}
+
+resource "aws_iam_policy" "code-deploy-allow-ecs" {
+  name   = "CodeDeployAllowECS"
+  path   = "/"
+  policy = data.aws_iam_policy_document.code-deploy-allow-ecs.json
+  tags   = local.default_tags
+}
+
+data "aws_iam_policy_document" "code-deploy-allow-ecs" {
+  statement {
+    sid       = "AccessRepository"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+  statement {
+    sid = "AllowPushRepository"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid = "RegisterTaskDefinition"
+    actions = [
+      "ecs:RegisterTaskDefinition",
+      "ecs:DescribeTaskDefinition"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid     = "PassRolesInTaskDefinition"
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.jarvis.arn,
+      aws_iam_role.ecs-execution-role.arn
+    ]
+  }
+  statement {
+    sid = "DeployService"
+    actions = [
+      "ecs:DescribeServices",
+      "codedeploy:GetDeploymentGroup",
+      "codedeploy:CreateDeployment",
+      "codedeploy:GetDeployment",
+      "codedeploy:GetDeploymentConfig",
+      "codedeploy:RegisterApplicationRevision"
+    ]
+    resources = [
+      aws_ecs_service.jarvis.id,
+      aws_codedeploy_app.jarvis.arn,
+      aws_codedeploy_deployment_group.jarvis.arn,
+      "arn:aws:codedeploy:us-east-1:833738481970:deploymentconfig:*"
+    ]
+  }
+}
+
+resource "aws_iam_role" "jarvis" {
+  name               = "Jarvis"
+  description        = "Allows ECS tasks to call AWS services on your behalf."
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.jarvis-assume-role-policy.json
+  tags               = local.default_tags
+}
+
+data "aws_iam_policy_document" "jarvis-assume-role-policy" {
+  statement {
+    sid     = ""
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "jarvis-manage-virtuals" {
+  role       = aws_iam_role.jarvis.name
+  policy_arn = aws_iam_policy.jarvis-manage-virtuals.arn
+}
+
+resource "aws_iam_policy" "jarvis-manage-virtuals" {
+  name   = "ManageTrainingVirtualsEc2"
+  policy = data.aws_iam_policy_document.jarvis-manage-virtuals.json
+  tags   = local.default_tags
+}
+
+data "aws_iam_policy_document" "jarvis-manage-virtuals" {
+  statement {
+    sid = "EditTrainingTemplateInstances"
+    actions = [
+      "ec2:RebootInstances",
+      "ec2:TerminateInstances",
+      "ec2:DeleteTags",
+      "ec2:StartInstances",
+      "ec2:CreateTags",
+      "ec2:RunInstances",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:StopInstances"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/aws:ec2launchtemplate:id"
+      values   = ["lt-069a2a56619110d61"]
+    }
+  }
+
+  statement {
+    sid       = "DescribeAllInstances"
+    actions   = ["ec2:DescribeInstances"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "ecs-execution-role" {
+  name               = "ecsTaskExecutionRole"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ecs-execution-role-assume-policy.json
+  tags               = local.default_tags
+}
+
+data "aws_iam_policy_document" "ecs-execution-role-assume-policy" {
+  statement {
+    sid     = ""
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-execution-role-ecs" {
+  role       = aws_iam_role.ecs-execution-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-execution-role-ssm" {
+  role       = aws_iam_role.ecs-execution-role.name
+  policy_arn = aws_iam_policy.ecs-execution-role-ssm.arn
+}
+
+resource "aws_iam_policy" "ecs-execution-role-ssm" {
+  name   = "SystemsManagerParameterAccess"
+  policy = data.aws_iam_policy_document.ecs-execution-role-ssm.json
+  tags   = local.default_tags
+}
+
+data "aws_iam_policy_document" "ecs-execution-role-ssm" {
+  statement {
+    sid       = "GetParams"
+    actions   = ["ssm:GetParameters"]
+    resources = ["arn:aws:ssm:us-east-1:833738481970:parameter/*"]
+  }
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -325,3 +325,57 @@ resource "aws_vpc_security_group_ingress_rule" "training-virtuals-all-icmp" {
   cidr_ipv4   = "0.0.0.0/0"
   ip_protocol = "icmp"
 }
+
+resource "aws_security_group" "jarvis" {
+  name        = "Jarvis"
+  description = "Base config for @jarvis."
+  vpc_id      = aws_vpc.supportops.id
+  tags        = local.default_tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "jarvis-default" {
+  security_group_id = aws_security_group.jarvis.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "jarvis-http-ipv4" {
+  description       = "traffic"
+  security_group_id = aws_security_group.jarvis.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 8080
+  to_port     = 8080
+}
+
+resource "aws_vpc_security_group_ingress_rule" "jarvis-http-ipv6" {
+  description       = "traffic"
+  security_group_id = aws_security_group.jarvis.id
+
+  cidr_ipv6   = "::/0"
+  ip_protocol = "tcp"
+  from_port   = 8080
+  to_port     = 8080
+}
+
+resource "aws_vpc_security_group_ingress_rule" "jarvis-health-ipv4" {
+  description       = "health"
+  security_group_id = aws_security_group.jarvis.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 7118
+  to_port     = 7118
+}
+
+resource "aws_vpc_security_group_ingress_rule" "jarvis-health-ipv6" {
+  description       = "health"
+  security_group_id = aws_security_group.jarvis.id
+
+  cidr_ipv6   = "::/0"
+  ip_protocol = "tcp"
+  from_port   = 7118
+  to_port     = 7118
+}

--- a/terraform/resources/jarvis-container-definitions.json
+++ b/terraform/resources/jarvis-container-definitions.json
@@ -1,0 +1,66 @@
+[
+  {
+      "name": "jarvis",
+      "image": "833738481970.dkr.ecr.us-east-1.amazonaws.com/jarvis:5ddd0f379679f151362f87556f025c8da379d30d",
+      "cpu": 0,
+      "portMappings": [
+          {
+              "name": "jarvis-8080-tcp",
+              "containerPort": 8080,
+              "hostPort": 8080,
+              "protocol": "tcp",
+              "appProtocol": "http"
+          },
+          {
+              "name": "jarvis-7118-tcp",
+              "containerPort": 7118,
+              "hostPort": 7118,
+              "protocol": "tcp",
+              "appProtocol": "http"
+          }
+      ],
+      "essential": true,
+      "environment": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+          {
+              "name": "AZURE_OPENAPI_KEY",
+              "valueFrom": "arn:aws:ssm:us-east-1:833738481970:parameter/azure/openai/key"
+          },
+          {
+              "name": "AZURE_SEARCH_ADMIN_KEY",
+              "valueFrom": "arn:aws:ssm:us-east-1:833738481970:parameter/azure/search/admin"
+          },
+          {
+              "name": "POSTGRES_PASSWORD",
+              "valueFrom": "arn:aws:ssm:us-east-1:833738481970:parameter/postgres/data/password"
+          },
+          {
+              "name": "POSTGRES_USER",
+              "valueFrom": "arn:aws:ssm:us-east-1:833738481970:parameter/postgres/data/user"
+          },
+          {
+              "name": "SLACK_BOT_TOKEN",
+              "valueFrom": "arn:aws:ssm:us-east-1:833738481970:parameter/slack/jarvis/bot_token"
+          },
+          {
+              "name": "SLACK_SIGNING_SECRET",
+              "valueFrom": "arn:aws:ssm:us-east-1:833738481970:parameter/slack/jarvis/signing_secret"
+          },
+          {
+              "name": "ZENDESK_API_AUTH",
+              "valueFrom": "arn:aws:ssm:us-east-1:833738481970:parameter/zendesk/api_token"
+          }
+      ],
+      "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+              "awslogs-create-group": "true",
+              "awslogs-group": "/ecs/jarvis",
+              "awslogs-region": "us-east-1",
+              "awslogs-stream-prefix": "ecs"
+          }
+      }
+  }
+]


### PR DESCRIPTION
Motivation
---
Thus far, J.A.R.V.I.S. has been manually run on the SupportOps EC2 instance. We want to put J.A.R.V.I.S. in a position where anyone can update him without having to fuss with RDP.

Modifications
---
* Created an ECR repository for J.A.R.V.I.S.
* Created an ECS cluster with a service to run Jarvis cheaply.
* Attached the J.A.R.V.I.S. container to the load balancer and redirected traffic to it.
* Set up CodeDeploy to manage blue/green deployments of the service

This pairs with a Github Actions workflow in the jarvis project that pushes a new container image and kicks off the blue/green deployment in CodeDeploy each time a revision is pushed to the main branch.

https://centeredge.atlassian.net/browse/DATA-622