### PR TITLE
Upgrade lambda runtime version (DO-5708)

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "email-handler" {
   s3_bucket   = "centeredge-techfiles"
   s3_key      = "lambda/emailHandler.zip"
   handler     = "index.handler"
-  runtime     = "nodejs18.x"
+  runtime     = "nodejs20.x"
   memory_size = 128
   timeout     = 3
   ephemeral_storage {


### PR DESCRIPTION
Motivation
---
We are forced to upgrade due to deprecations.

Modifications
---
Set the runtime for the emailHandler function to `nodejs20.x`.

https://centeredge.atlassian.net/browse/DO-5708
