### PR TITLE
Tune Jarvis ALB health and deregistration timings (PHNX-18247)

### DIFF
--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -160,6 +160,7 @@ resource "aws_lb_target_group" "jarvis-2" {
   protocol                      = "HTTP"
   protocol_version              = "HTTP1"
   connection_termination        = false
+  deregistration_delay          = 120
   ip_address_type               = "ipv4"
   load_balancing_algorithm_type = "round_robin"
   proxy_protocol_v2             = false
@@ -168,7 +169,7 @@ resource "aws_lb_target_group" "jarvis-2" {
 
   health_check {
     enabled             = true
-    healthy_threshold   = 5
+    healthy_threshold   = 2
     interval            = 30
     matcher             = "200"
     path                = "/healthcheck"


### PR DESCRIPTION
Motivation
----------
Improve Jarvis deployment speed by reducing the time required for targets to become healthy and for old targets to drain.

Modifications
-------------
- Updated `terraform/lb.tf` for `aws_lb_target_group "jarvis-2"` to set `healthy_threshold` from `5` to `2`.
- Added `deregistration_delay = 120` to reduce target deregistration wait time from the default `300` seconds.

https://centeredge.atlassian.net/browse/PHNX-18247
